### PR TITLE
changing quotes to inline code

### DIFF
--- a/_episodes/03-types-conversion.md
+++ b/_episodes/03-types-conversion.md
@@ -81,7 +81,7 @@ TypeError: unsupported operand type(s) for -: 'str' and 'str'
 ~~~
 {: .error}
 
-## You can use the "+" and "*" operators on strings.
+## You can use the `+` and `*` operators on strings.
 
 *   "Adding" character strings concatenates them.
 


### PR DESCRIPTION
This header has references to "+" and "*" as operators when it wasn't meant to indicate that they are string objects.  I'm proposing this is changed to inline code to match other styling and reduce confusion.