### PR TITLE
clarifying when the quotes don't appear

### DIFF
--- a/_episodes/03-types-conversion.md
+++ b/_episodes/03-types-conversion.md
@@ -27,7 +27,7 @@ keypoints:
     *   Integers are used to count, floats are used to measure.
 *   Character string (usually called "string", `str`): text.
     *   Written in either single quotes or double quotes (as long as they match).
-    *   The quotation marks aren't printed when the string is displayed.
+    *   The quotation marks aren't printed using `print()`, but may appear when viewing a value in the Jupyter Notebook or other Python interpreter.
 
 ## Use the built-in function `type` to find the type of a value.
 


### PR DESCRIPTION
"Integers are used to count, floats are used to measure" I think this isn't helpful for this context.  I've also fussed over the wording a bit and adding some clarification about whole numbers being stored as floats.