### PR TITLE
simplifying language on syntax errors

### DIFF
--- a/_episodes/04-built-in.md
+++ b/_episodes/04-built-in.md
@@ -135,9 +135,12 @@ round(...)
 ~~~
 {: .output}
 
-## Python reports a syntax error when it can't understand the source of a program.
+## Python reports a syntax error when grammar rules have been violated.
 
-*   Won't even try to run the program if it can't be parsed.
+*   You've seen errors when you try to use a function incorrectly.
+    * Can also have errors when you use punctuation incorrectly.
+*   Python will run the program up until that point, but if the grammar of that line 
+    of code has produced an error, then the program will shut down with an error.
 
 ~~~
 # Forgot to close the quotation marks around the string.

--- a/_episodes/04-built-in.md
+++ b/_episodes/04-built-in.md
@@ -135,7 +135,7 @@ round(...)
 ~~~
 {: .output}
 
-## Python reports a syntax error when grammar rules (that's Python grammar not English grammar) have been violated.
+## Python reports a syntax error when grammar rules (that's Python grammar, not English grammar) have been violated.
 
 *   You've seen errors when you try to use a function incorrectly.
     * Can also have errors when you use punctuation incorrectly.

--- a/_episodes/04-built-in.md
+++ b/_episodes/04-built-in.md
@@ -135,7 +135,7 @@ round(...)
 ~~~
 {: .output}
 
-## Python reports a syntax error when grammar rules have been violated.
+## Python reports a syntax error when grammar rules (that's Python grammar not English grammar) have been violated.
 
 *   You've seen errors when you try to use a function incorrectly.
     * Can also have errors when you use punctuation incorrectly.


### PR DESCRIPTION
Tried to simplify the language in the header.  I also wanted to change this statement: "Won’t even try to run the program if it can’t be parsed" Python has to run the program up until that point to even see the error, but the script will shut down if the line of code can't be parsed.  So this statement is very confusing.

I also fussed with the wording to focus more on linguistic synonyms, which usually hits better with a librarian crowd.